### PR TITLE
Subdirectory install fix

### DIFF
--- a/curatescape-echo/custom.php
+++ b/curatescape-echo/custom.php
@@ -644,7 +644,7 @@ function rl_homepage_map($ishome=true,$totalItems=null)
         </figure>
       </div>
       <?php if($ishome):?>
-      <div class="view-more-link"><a class="button" href="/items/map"><?php echo __('View Map Page');?></a></div>
+      <div class="view-more-link"><a class="button" href=<?php echo url('items/map').'>'.__('View Map Page');?></a></div>
       <?php endif;?>
     </section>
     <?php
@@ -958,7 +958,7 @@ $q = $select->query();
           if ($results) {
               $html.='<div id="tour-for-item"><ul>';
               foreach ($results as $result) {
-                  $html.='<li><a class="tag tag-alt" href="/tours/show/'.$result['id'].'">';
+                  $html.='<li><a class="tag tag-alt" href="'.url('tours/show/').$result['id'].'">';
                   $html.=$result['title'];
                   $html.='</a></li>';
               }
@@ -1200,7 +1200,7 @@ function rl_file_caption($file, $includeTitle=true)
     $caption=array();
 
     $title = metadata($file, array( 'Dublin Core', 'Title' ));
-    $caption[] = '<span class="file-title" itemprop="name"><cite><a itemprop="contentUrl" title="'.__('View File Record').'" href="/files/show/'.$file->id.'">'.($title ? $title : __('Untitled')).'</a></cite></span>';
+    $caption[] = '<span class="file-title" itemprop="name"><cite><a itemprop="contentUrl" title="'.__('View File Record').'" href='.url('files/show/').$file->id.'>'.($title ? $title : __('Untitled')).'</a></cite></span>';
 
     if ($description = metadata($file, array( 'Dublin Core', 'Description' ))) {
         $caption[]= '<span class="file-description">'.strip_tags($description, '<a><u><strong><em><i><cite>').'</span>';
@@ -1574,7 +1574,7 @@ function rl_homepage_featured($num=4,$html=null,$index=1)
         }
       $html .= $primary.'<div class="secondary">'.$secondary.'</div>';
       $html .= '</div>';
-      $html .= '<div class="view-more-link"><a class="button" href="/items/browse?featured=1">'.__('Browse All Featured %2s', rl_item_label('plural')).'</a></div>';
+      $html .= '<div class="view-more-link"><a class="button" href="'.url('items').'?featured=1">'.__('Browse All Featured %2s', rl_item_label('plural')).'</a></div>';
       return '<section id="home-featured" class="inner-padding browse">'.$html.'</section>';
     }else{
       return rl_admin_message('home-featured',array('admin','super'));
@@ -1630,7 +1630,7 @@ function rl_homepage_recent_random($num=3,$html=null,$index=1)
           $html .= '</article>';
         }
       $html .= '</div>';
-      $html .= '<div class="view-more-link"><a class="button" href="/items/browse/">'.__('Browse All %2s', rl_item_label('plural')).'</a></div>';
+      $html .= '<div class="view-more-link"><a class="button" href="'.url('items').'">'.__('Browse All %2s', rl_item_label('plural')).'</a></div>';
       return '<section id="home-recent-random" class="browse inner-padding">'.$html.'</section>';
     }else{
       return rl_admin_message('home-recent-random',array('admin','super'));
@@ -1647,8 +1647,8 @@ function rl_homepage_tags($num=25)
     $tags=get_records('Tag', array('sort_field' => 'count', 'sort_dir' => 'd'), $num);
     if(count($tags)){
       $html = '<h2 class="query-header">'.__('Popular Tags').'</h2>';
-      $html.=tag_cloud($tags, url('items/browse'));
-      $html.='<div class="view-more-link"><a class="button" href="/items/tags/">'.__('Browse All Tags').'</a></div>';
+      $html.=tag_cloud($tags, 'items/browse');
+      $html.='<div class="view-more-link"><a class="button" href="'.url('items/tags').'">'.__('Browse All Tags').'</a></div>';
       return '<section id="home-tags" class="inner-padding">'.$html.'</section>';    
     }else{
       return rl_admin_message('home-tags',array('admin','super'));
@@ -1975,7 +1975,7 @@ function rl_display_random_featured_item($withImage=false, $num=1)
                      $html .=rl_hero_item($item);
         endforeach;
 
-        $html.='<p class="view-more-link"><a class="button" href="/items/browse?featured=1">'.__('Browse Featured %s', rl_item_label('plural')).'</a></p>';
+        $html.='<p class="view-more-link"><a class="button" href="'.url('items').'?featured=1">'.__('Browse Featured %s', rl_item_label('plural')).'</a></p>';
     } else {
         $html .= '<article class="featured-story-result none">';
         $html .= '<p>'.__('No featured items are available. Publish some now.').'</p>';

--- a/curatescape-echo/items/tags.php
+++ b/curatescape-echo/items/tags.php
@@ -22,7 +22,7 @@
         </div>
         <div id="primary" class="">
             <section id="tags" aria-label="<?php echo __('Tags');?>">
-                <?php echo tag_cloud($tags, url('items/browse'), 9, true, 'after'); ?>
+                <?php echo tag_cloud($tags, 'items/browse', 9, true, 'after'); ?>
             </section>
         </div><!-- end primary -->
 


### PR DESCRIPTION
Makes changes to relative urls so that they work on an omeka instance installed in a subdirectory

- Wraps many relative urls in custom.php in omeka's url() function to handle different install location strategies.
- Removes url() function from tag_cloud() parameters on homepage and in tags template, since it was adding the subdirectory to urls twice, e.g. `domain.com/omeka_location/omeka_location/items/browse?tags=TAG`

Subdirectory installs also break the multi-map.js display on homepage and items/map  as mentioned in issue #3  but that is not addressed here since I couldn't find a robust solution and hard coded it on my installation. 

See changes in action at https://hhfinals.dgah.sites.carleton.edu/carlclubs/
